### PR TITLE
Added Manticore support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,13 @@ To find out more details, please visit our [wiki](https://github.com/hxuhack/log
  [How to install python packages](https://packaging.python.org/tutorials/installing-packages/)
  
 As angr and triton scripts were written by Python 2, you should install `termcolor` and `psutil` for both Python 2 and Python 3.
+Manticore will only run with Python 3.6 (or greater)
  
 Besides these dependencies, you should also build the environment for your target symbolic engines.
 - [How to install angr](https://docs.angr.io/INSTALL.html)
 - [How to install KLEE](http://klee.github.io/getting-started/)
 - [How to install Triton](https://triton.quarkslab.com/documentation/doxygen/#install_sec)
-
+- [How to install Manticore](https://github.com/trailofbits/manticore#quickstart)
 
 ## How to run it?
 First, clone our repo by using  `git clone https://github.com/hxuhack/logic_bombs.git`.
@@ -66,6 +67,7 @@ The available engine names are:
  - triton
  - triton_cpp
  - klee
+ - manticore
 
 And the typical max running time setting is 60s or 300s.
 

--- a/config/compile.json
+++ b/config/compile.json
@@ -1,6 +1,6 @@
 {
     "general": {
-        "CC": "clang"
+        "CC": "gcc"
     },
 
     "crypto_lib": {
@@ -54,7 +54,7 @@
             "build"
         ],
         "cmd": [
-            "{CC} -I{INCLUDE} -Lbuild -o build/{&FILENAME} -xc - -lpthread -lm -lutils -lcrypto #PIPE"
+            "{CC} -I{INCLUDE} -static -O0 -Lbuild -o build/{&FILENAME} -xc - -lpthread -lm -lutils -lcrypto #PIPE"
         ],
         "dependencies": {
             "PATH": "src/",

--- a/config/test_settings.py
+++ b/config/test_settings.py
@@ -24,10 +24,10 @@ cmds_tp_triton_cpp = [
 ]
 
 cmds_tp_mcore = ["clang -static -O0 -Iinclude -Lbuild -o mcore/%s.out -xc - -lutils -lpthread -lcrypto -lm",
-            "python3 script/mcore_run.py -r -l%d mcore/%s.out"]
+            "python3 script/mcore_run.py -t%d -r -l%d mcore/%s.out"]
 
 cmds_tp_mcore_cpp = ["clang++ -static -O0 -Iinclude -Lbuild -o mcore/%s.out -xc++ - -lutils -lpthread -lcrypto -lm",
-            "python3 script/mcore_run.py -r -l%d mcore/%s.out"]
+            "python3 script/mcore_run.py -t%d -r -l%d mcore/%s.out"]
 
 angr_tp_path = 'templates/default_no_printf.c'
 triton_tp_path = 'templates/default_no_printf.c'

--- a/config/test_settings.py
+++ b/config/test_settings.py
@@ -23,9 +23,16 @@ cmds_tp_triton_cpp = [
     "python script/triton_caller.py -l%d -m%d -f%s -i%s -p triton/%s.out"
 ]
 
+cmds_tp_mcore = ["clang -static -O0 -Iinclude -Lbuild -o mcore/%s.out -xc - -lutils -lpthread -lcrypto -lm",
+            "python3 script/mcore_run.py -r -l%d mcore/%s.out"]
+
+cmds_tp_mcore_cpp = ["clang++ -static -O0 -Iinclude -Lbuild -o mcore/%s.out -xc++ - -lutils -lpthread -lcrypto -lm",
+            "python3 script/mcore_run.py -r -l%d mcore/%s.out"]
+
 angr_tp_path = 'templates/default_no_printf.c'
 triton_tp_path = 'templates/default_no_printf.c'
 klee_tp_path = 'templates/klee.c'
+mcore_tp_path = 'templates/default_no_printf.c'
 
 switches = {
     'angr': [cmds_tp_angr, angr_tp_path, 'angr', ('src/', )],
@@ -33,6 +40,8 @@ switches = {
     'triton': [cmds_tp_triton, triton_tp_path, 'triton', ('src/', )],
     'triton_cpp': [cmds_tp_triton_cpp, triton_tp_path, 'triton', ('src_cpp/', )],
     'klee': [cmds_tp_klee, klee_tp_path, 'klee', ('src/', )],
+    'mcore': [cmds_tp_mcore, mcore_tp_path, 'mcore', ('src/', )],
+    'mcore_cpp': [cmds_tp_mcore_cpp, mcore_tp_path, 'mcore', ('src_cpp/', )],
 }
 
 # ============ triton Setting ==============

--- a/run_tests.py
+++ b/run_tests.py
@@ -122,6 +122,28 @@ def ATKrun(target, func_name='logic_bomb', default_stdin_len=10, maxtime=60, sou
                         test_results[fp] = TLE
                         kill_all(p)
 
+                if prefix == 'mcore':
+                    cmds.append(cmds_tp[0] % outname)
+                    cmds.append(cmds_tp[1] % (default_stdin_len, outname))
+
+                    # Compile
+                    p = subprocess.Popen(cmds[0].split(' '), stdin=subprocess.PIPE)
+                    p.communicate(res.encode('utf8'))
+                    cp_value = p.wait()
+                    if cp_value:
+                        test_results[fp] = COMPILE_ERROR
+                        print('========= Compile Error! ==========')
+                        continue
+                    # Run test
+                    p = subprocess.Popen(cmds[1].split(' '))
+                    print(p.pid)
+                    try:
+                        rt_vale = p.wait(timeout=MAX_TIME)
+                        test_results[fp] = rt_vale
+                    except subprocess.TimeoutExpired:
+                        test_results[fp] = TLE
+                        kill_all(p)
+
                 elif prefix == 'klee':
                     if not os.path.exists('klee'):
                         os.mkdir('klee')

--- a/run_tests.py
+++ b/run_tests.py
@@ -138,9 +138,9 @@ def ATKrun(target, func_name='logic_bomb', default_stdin_len=10, maxtime=60, sou
                     p = subprocess.Popen(cmds[1].split(' '))
                     print(p.pid)
                     try:
-                        rt_vale = p.wait(timeout=MAX_TIME)
-                        test_results[fp] = rt_vale
-                    except subprocess.TimeoutExpired:
+                      rt_vale = p.wait()
+                      test_results[fp] = rt_vale
+                    except:
                         test_results[fp] = TLE
                         kill_all(p)
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -124,7 +124,7 @@ def ATKrun(target, func_name='logic_bomb', default_stdin_len=10, maxtime=60, sou
 
                 if prefix == 'mcore':
                     cmds.append(cmds_tp[0] % outname)
-                    cmds.append(cmds_tp[1] % (MAX_TIME, default_stdin_len, outname))
+                    cmds.append(cmds_tp[1] % (MAX_TIME-30, default_stdin_len, outname))
 
                     # Compile
                     p = subprocess.Popen(cmds[0].split(' '), stdin=subprocess.PIPE)
@@ -138,7 +138,7 @@ def ATKrun(target, func_name='logic_bomb', default_stdin_len=10, maxtime=60, sou
                     p = subprocess.Popen(cmds[1].split(' '))
                     print(p.pid)
                     try:
-                      rt_vale = p.wait()
+                      rt_vale = p.wait(timeout=MAX_TIME)
                       test_results[fp] = rt_vale
                     except:
                         test_results[fp] = TLE

--- a/run_tests.py
+++ b/run_tests.py
@@ -124,7 +124,7 @@ def ATKrun(target, func_name='logic_bomb', default_stdin_len=10, maxtime=60, sou
 
                 if prefix == 'mcore':
                     cmds.append(cmds_tp[0] % outname)
-                    cmds.append(cmds_tp[1] % (default_stdin_len, outname))
+                    cmds.append(cmds_tp[1] % (MAX_TIME, default_stdin_len, outname))
 
                     # Compile
                     p = subprocess.Popen(cmds[0].split(' '), stdin=subprocess.PIPE)

--- a/script/mcore_run.py
+++ b/script/mcore_run.py
@@ -13,8 +13,7 @@ from termcolor import colored
 def run_symexe(path, argv_size=2, show_bytes=True, show_model=False, timeout=60):
 
     consts = config.get_group("core")
-    consts.procs = 1
-    #consts.mprocessing = "single"
+    consts.procs = 4
     
     try:
         m = Manticore(path, argv=['+'*argv_size])

--- a/script/mcore_run.py
+++ b/script/mcore_run.py
@@ -1,0 +1,121 @@
+import os
+import sys
+import time
+import argparse
+import subprocess
+import csv
+
+from manticore.native import Manticore
+from manticore.core.smtlib.solver import Z3Solver
+from termcolor import colored
+
+def run_symexe(path, argv_size=2, show_bytes=True, show_model=False):
+
+    try:
+        m = Manticore(path, argv=['+'*argv_size])
+    except:
+        print(colored('Invalid path: \"' + path + '\"', 'red'))
+        return None
+
+    m.run()
+    results = []
+
+    for state in m.all_states:
+        for symbol in state.input_symbols:
+            if (symbol.name == 'ARGV1'):
+                res = Z3Solver().get_value(state.constraints, symbol)
+                results.append(res)
+
+        if show_bytes:
+            print(colored(b'[+] New Input: ' + res + b' |', 'green'))
+            # print(colored('ASCII:', 'cyan'), end="")
+            # for char in res:
+            #     print(colored(ord(char), 'cyan'), end=" ")
+            # print('')
+            if show_model:
+                print(colored(str(dd.solver.constraints), 'yellow'))
+        else:
+            print(colored('[+] New Input: ' + res, 'green'))
+
+    errored = False
+    return results, errored
+
+
+if __name__ == '__main__':
+    print('\n')
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-c", "--constraints", help="Show generated model", action="store_true")
+    parser.add_argument("-C", "--compile", type=int, help="Compile from source, if C > 0, -O option will be used")
+    parser.add_argument("-l", "--length", type=int, help="Stdin size")
+    parser.add_argument("-r", "--run_program", help="Run program after analysis", action="store_true")
+    parser.add_argument("-s", "--summary", type=int, help="Display summary information")
+    parser.add_argument("-e", "--expected", type=int, help="Expected amount of results")
+    parser.add_argument("file_path", type=str, help="Binary path")
+    args = parser.parse_args()
+
+    if args.compile is not None:
+        print(colored('[*] Compiling...', 'cyan'))
+        bin_dir, filename = os.path.split(args.file_path)
+        if args.compile != 0:
+            cmd = ' '.join(['gcc -o', os.path.join(bin_dir, filename[0] + '.out'),
+                           '-O' + str(args.compile), args.file_path])
+        else:
+            cmd = ' '.join(['gcc -o', os.path.join(bin_dir, filename[0] + '.out'), args.file_path])
+        print(cmd)
+        os.system(cmd)
+        print(colored('[*] Compile completed\n', 'green'))
+        bin_path = os.path.join(bin_dir, filename[0] + '.out')
+    else:
+        bin_path = args.file_path
+
+    #print(colored('[*] Analysing...', 'cyan'))
+    if args.length is None:
+        results, errored = run_symexe(bin_path, 10, show_model=args.constraints)
+    else:
+        results, errored = run_symexe(bin_path, args.length, show_model=args.constraints)
+    print(colored('[*] Analysis completed\n', 'green'))
+
+    # tohex = lambda x: ''.join(['\\x%02x' % ord(c) for c in x])
+    # with open('angr_outputs.csv', 'ab') as csvfile:
+    #     writer = csv.writer(csvfile)
+    #     writer.writerow([args.file_path, ] + [tohex(_) for _ in results])
+
+    tests = []
+    print(results, args.run_program)
+    if results is not None and args.run_program:
+        bin_dir, filename = os.path.split(args.file_path)
+        for i, res in enumerate(results):
+            print(colored('[*] Result ' + str(i + 1) + ':', 'yellow'))
+            res = res.split(b'\x00')[0]
+            # print('Calling: ' + ' '.join([os.path.join(bin_dir, filename), res]))
+            pipe = subprocess.Popen([os.path.join(bin_dir, filename), res])
+            single_run = pipe.wait()
+            output = 'return value:' + str(single_run) + '\n'
+            tests.append(single_run)
+            print(colored(output, 'yellow'))
+
+        if args.summary is not None:
+            cnt = 0
+            for i in set(tests):
+                if i in list(range(len(results))):
+                    cnt += 1
+            coverage = 100 * cnt / args.summary
+
+            if coverage <= 100 and coverage > 95:
+                color = 'green'
+            elif coverage <= 95 and coverage > 85:
+                color = 'cyan'
+            elif coverage <= 85 and coverage > 60:
+                color = 'yellow'
+            else:
+                color = 'red'
+        
+        if 3 in tests:
+            exit(1)
+        elif errored or 139 in tests:
+            exit(-1)
+        elif 0 in tests:
+            exit(0)
+        else:
+            exit(-1)
+

--- a/script/mcore_run.py
+++ b/script/mcore_run.py
@@ -10,7 +10,7 @@ from manticore.core.smtlib.solver import Z3Solver
 from manticore.utils import config
 from termcolor import colored
 
-def run_symexe(path, argv_size=2, show_bytes=True, show_model=False):
+def run_symexe(path, argv_size=2, show_bytes=True, show_model=False, timeout=60):
 
     consts = config.get_group("core")
     consts.procs = 1
@@ -22,7 +22,7 @@ def run_symexe(path, argv_size=2, show_bytes=True, show_model=False):
         print(colored('Invalid path: \"' + path + '\"', 'red'))
         return None
 
-    with m.kill_timeout(60):
+    with m.kill_timeout(timeout):
         m.run()
         results = []
 
@@ -56,6 +56,8 @@ if __name__ == '__main__':
     parser.add_argument("-r", "--run_program", help="Run program after analysis", action="store_true")
     parser.add_argument("-s", "--summary", type=int, help="Display summary information")
     parser.add_argument("-e", "--expected", type=int, help="Expected amount of results")
+    parser.add_argument("-t", "--timeout", type=int, help="Timeout (in seconds)")
+
     parser.add_argument("file_path", type=str, help="Binary path")
     args = parser.parse_args()
 
@@ -76,9 +78,9 @@ if __name__ == '__main__':
 
     #print(colored('[*] Analysing...', 'cyan'))
     if args.length is None:
-        results, errored = run_symexe(bin_path, 10, show_model=args.constraints)
+        results, errored = run_symexe(bin_path, 10, show_model=args.constraints, timeout=args.timeout)
     else:
-        results, errored = run_symexe(bin_path, args.length, show_model=args.constraints)
+        results, errored = run_symexe(bin_path, args.length, show_model=args.constraints, timeout=args.timeout)
     print(colored('[*] Analysis completed\n', 'green'))
 
     # tohex = lambda x: ''.join(['\\x%02x' % ord(c) for c in x])


### PR DESCRIPTION
This PR will add manticore into the list of symbolic execution engines to test. To test, you should use `mcore` as the engine name.